### PR TITLE
MsSql2008 schema support for multiple eventstores in a single database instance

### DIFF
--- a/src/Cedar.EventStore.MsSql2008.Tests/MsSqlEventStoreFixture.cs
+++ b/src/Cedar.EventStore.MsSql2008.Tests/MsSqlEventStoreFixture.cs
@@ -9,11 +9,13 @@ namespace Cedar.EventStore
     public class MsSqlEventStoreFixture : EventStoreAcceptanceTestFixture
     {
         public readonly string ConnectionString;
+        private readonly string _schema;
         private readonly ISqlLocalDbInstance _localDbInstance;
         private readonly string _databaseName;
 
-        public MsSqlEventStoreFixture()
+        public MsSqlEventStoreFixture(string schema)
         {
+            _schema = schema;
             var localDbProvider = new SqlLocalDbProvider
             {
                 Version = "11.0"
@@ -31,8 +33,16 @@ namespace Cedar.EventStore
         {
             await CreateDatabase();
 
-            var eventStore = new MsSqlEventStore(ConnectionString, Poller.CreateEventStoreNotifier());
+            var eventStore = new MsSqlEventStore(ConnectionString, Poller.CreateEventStoreNotifier(), _schema);
             await eventStore.DropAll(ignoreErrors: true);
+            await eventStore.InitializeStore();
+
+            return eventStore;
+        }
+
+        public async Task<IEventStore> GetEventStore(string schema)
+        {
+            var eventStore = new MsSqlEventStore(ConnectionString, Poller.CreateEventStoreNotifier(), schema);
             await eventStore.InitializeStore();
 
             return eventStore;
@@ -46,14 +56,14 @@ namespace Cedar.EventStore
                 SqlConnection.ClearPool(sqlConnection);
             }
 
-            using (var connection = _localDbInstance.CreateConnection())
+            /*using (var connection = _localDbInstance.CreateConnection())
             {
                 connection.Open();
                 using (var command = new SqlCommand($"DROP DATABASE {_databaseName}", connection))
                 {
                     command.ExecuteNonQuery();
                 }
-            }
+            }*/
         }
 
         private async Task CreateDatabase()

--- a/src/Cedar.EventStore.MsSql2008.Tests/MsSqlEventStoreFixture.cs
+++ b/src/Cedar.EventStore.MsSql2008.Tests/MsSqlEventStoreFixture.cs
@@ -56,14 +56,14 @@ namespace Cedar.EventStore
                 SqlConnection.ClearPool(sqlConnection);
             }
 
-            /*using (var connection = _localDbInstance.CreateConnection())
+            using (var connection = _localDbInstance.CreateConnection())
             {
                 connection.Open();
                 using (var command = new SqlCommand($"DROP DATABASE {_databaseName}", connection))
                 {
                     command.ExecuteNonQuery();
                 }
-            }*/
+            }
         }
 
         private async Task CreateDatabase()

--- a/src/Cedar.EventStore.MsSql2008.Tests/MsSqlEventStoreTests.cs
+++ b/src/Cedar.EventStore.MsSql2008.Tests/MsSqlEventStoreTests.cs
@@ -1,10 +1,42 @@
 ﻿namespace Cedar.EventStore
 {
+    using System.Threading.Tasks;
+    using Cedar.EventStore.Streams;
+    using Shouldly;
+    using Xunit;
+
     public partial class EventStoreAcceptanceTests
     {
-        public EventStoreAcceptanceTestFixture GetFixture()
+        private EventStoreAcceptanceTestFixture GetFixture(string schema = "foo")
         {
-            return new MsSqlEventStoreFixture();
+            return new MsSqlEventStoreFixture(schema);
+        }
+
+        [Fact]
+        public async Task Can_use_multiple_schemas()
+        {
+            using(var fixture = new MsSqlEventStoreFixture("dbo"))
+            {
+                using(var dboEventStore = await fixture.GetEventStore())
+                {
+                    using(var barEventStore = await fixture.GetEventStore("bar"))
+                    {
+                        await dboEventStore.AppendToStream("stream-1",
+                                ExpectedVersion.NoStream,
+                                CreateNewStreamEvents(1, 2));
+                        await barEventStore.AppendToStream("stream-1",
+                                ExpectedVersion.NoStream,
+                                CreateNewStreamEvents(1, 2));
+
+                        var dboHeadCheckpoint = await dboEventStore.ReadHeadCheckpoint();
+                        var fooHeadCheckpoint = await dboEventStore.ReadHeadCheckpoint();
+
+                        dboHeadCheckpoint.ShouldBe(1);
+                        fooHeadCheckpoint.ShouldBe(1);
+
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.AppendStream.cs
+++ b/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.AppendStream.cs
@@ -7,7 +7,6 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Cedar.EventStore.Infrastructure;
-    using Cedar.EventStore.SqlScripts;
     using Cedar.EventStore.Streams;
     using EnsureThat;
     using Microsoft.SqlServer.Server;
@@ -60,7 +59,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using (var command = new SqlCommand(Scripts.AppendStreamExpectedVersionAny, connection))
+                using (var command = new SqlCommand(_scripts.AppendStreamExpectedVersionAny, connection))
                 {
                     command.Parameters.AddWithValue("streamId", streamIdInfo.Hash);
                     command.Parameters.AddWithValue("streamIdOriginal", streamIdInfo.Id);
@@ -136,7 +135,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using (var command = new SqlCommand(Scripts.AppendStreamExpectedVersionNoStream, connection))
+                using (var command = new SqlCommand(_scripts.AppendStreamExpectedVersionNoStream, connection))
                 {
                     command.Parameters.AddWithValue("streamId", streamIdHash.Hash);
                     command.Parameters.AddWithValue("streamIdOriginal", streamIdHash.Id);
@@ -212,7 +211,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using (var command = new SqlCommand(Scripts.AppendStreamExpectedVersion, connection))
+                using (var command = new SqlCommand(_scripts.AppendStreamExpectedVersion, connection))
                 {
                     command.Parameters.AddWithValue("streamId", streamIdHash.Hash);
                     command.Parameters.AddWithValue("expectedStreamVersion", expectedVersion);

--- a/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.AppendStream.cs
+++ b/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.AppendStream.cs
@@ -286,11 +286,11 @@
             return sqlDataRecords;
         }
 
-        private static SqlParameter CreateNewEventsSqlParameter(SqlDataRecord[] sqlDataRecords)
+        private SqlParameter CreateNewEventsSqlParameter(SqlDataRecord[] sqlDataRecords)
         {
             var eventsParam = new SqlParameter("newEvents", SqlDbType.Structured)
             {
-                TypeName = "dbo.NewStreamEvents",
+                TypeName = $"{_scripts.Schema}.NewStreamEvents",
                 Value = sqlDataRecords
             };
             return eventsParam;

--- a/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.ReadAll.cs
+++ b/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.ReadAll.cs
@@ -6,7 +6,6 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Cedar.EventStore.Infrastructure;
-    using Cedar.EventStore.SqlScripts;
     using Cedar.EventStore.Streams;
 
     public partial class MsSqlEventStore
@@ -14,7 +13,7 @@
         protected override async Task<AllEventsPage> ReadAllForwardsInternal(
             long fromCheckpointExlusive,
             int maxCount,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken)
         {
             long ordinal = fromCheckpointExlusive;
 
@@ -22,7 +21,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using (var command = new SqlCommand(Scripts.ReadAllForward, connection))
+                using (var command = new SqlCommand(_scripts.ReadAllForward, connection))
                 {
                     command.Parameters.AddWithValue("ordinal", ordinal);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not
@@ -96,7 +95,7 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using (var command = new SqlCommand(Scripts.ReadAllBackward, connection))
+                using (var command = new SqlCommand(_scripts.ReadAllBackward, connection))
                 {
                     command.Parameters.AddWithValue("ordinal", ordinal);
                     command.Parameters.AddWithValue("count", maxCount + 1); //Read extra row to see if at end or not

--- a/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.ReadStream.cs
+++ b/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.ReadStream.cs
@@ -77,7 +77,8 @@
                 var doesNotExist = reader.IsDBNull(0);
                 if(doesNotExist)
                 {
-                    return new StreamEventsPage(streamId,
+                    return new StreamEventsPage(
+                        streamId,
                         PageReadStatus.StreamNotFound,
                         start,
                         -1,
@@ -90,7 +91,8 @@
                 var isDeleted = reader.GetBoolean(0);
                 if(isDeleted)
                 {
-                    return new StreamEventsPage(streamId,
+                    return new StreamEventsPage(
+                        streamId,
                         PageReadStatus.StreamDeleted,
                         0,
                         0,
@@ -112,7 +114,8 @@
                     var jsonData = reader.GetString(5);
                     var jsonMetadata = reader.GetString(6);
 
-                    var streamEvent = new StreamEvent(streamId,
+                    var streamEvent = new StreamEvent(
+                        streamId,
                         eventId,
                         streamVersion1,
                         ordinal,

--- a/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.ReadStream.cs
+++ b/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.ReadStream.cs
@@ -7,7 +7,6 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Cedar.EventStore.Infrastructure;
-    using Cedar.EventStore.SqlScripts;
     using Cedar.EventStore.Streams;
 
     public partial class MsSqlEventStore
@@ -40,7 +39,7 @@
             }
         }
 
-        private static async Task<StreamEventsPage> ReadStreamInternal(
+        private async Task<StreamEventsPage> ReadStreamInternal(
             string streamId,
             int start,
             int count,
@@ -56,12 +55,12 @@
             Func<List<StreamEvent>, int> getNextSequenceNumber;
             if(direction == ReadDirection.Forward)
             {
-                commandText = Scripts.ReadStreamForward;
+                commandText = _scripts.ReadStreamForward;
                 getNextSequenceNumber = events => events.Last().StreamVersion + 1;
             }
             else
             {
-                commandText = Scripts.ReadStreamBackward;
+                commandText = _scripts.ReadStreamBackward;
                 getNextSequenceNumber = events => events.Last().StreamVersion - 1;
             }
 

--- a/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.cs
+++ b/src/Cedar.EventStore.MsSql2008/MsSqlEventStore.cs
@@ -104,7 +104,17 @@
             {
                 await connection.OpenAsync(cancellationToken).NotOnCapturedContext();
 
-                using(var command = new SqlCommand(_scripts.InitializeStore, connection))
+                if(_scripts.Schema != "dbo")
+                {
+                    using(var command = new SqlCommand($"CREATE SCHEMA {_scripts.Schema}", connection))
+                    {
+                        await command
+                            .ExecuteNonQueryAsync(cancellationToken)
+                            .NotOnCapturedContext();
+                    }
+                }
+
+                using (var command = new SqlCommand(_scripts.InitializeStore, connection))
                 {
                     if(ignoreErrors)
                     {

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersion.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersion.sql
@@ -3,9 +3,9 @@ BEGIN TRANSACTION AppendStream;
     DECLARE @streamIdInternal AS INT;
     DECLARE @latestStreamVersion AS INT;
 
-     SELECT @streamIdInternal = Streams.IdInternal
-       FROM Streams
-      WHERE Streams.Id = @streamId;
+     SELECT @streamIdInternal = dbo.Streams.IdInternal
+       FROM dbo.Streams
+      WHERE dbo.Streams.Id = @streamId;
 
          IF @streamIdInternal IS NULL
         BEGIN
@@ -15,10 +15,10 @@ BEGIN TRANSACTION AppendStream;
         END
 
         SELECT TOP(1)
-             @latestStreamVersion = Events.StreamVersion
-        FROM Events
-       WHERE Events.StreamIDInternal = @streamIdInternal
-    ORDER BY Events.Ordinal DESC;
+             @latestStreamVersion = dbo.Events.StreamVersion
+        FROM dbo.Events
+       WHERE dbo.Events.StreamIDInternal = @streamIdInternal
+    ORDER BY dbo.Events.Ordinal DESC;
 
         IF @latestStreamVersion != @expectedStreamVersion
         BEGIN

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersionAny.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersionAny.sql
@@ -3,9 +3,9 @@ BEGIN TRANSACTION AppendStream;
     DECLARE @streamIdInternal AS INT;
     DECLARE @latestStreamVersion AS INT;
 
-     SELECT @streamIdInternal = Streams.IdInternal
-       FROM Streams
-      WHERE Streams.Id = @streamId;
+     SELECT @streamIdInternal = dbo.Streams.IdInternal
+       FROM dbo.Streams
+      WHERE dbo.Streams.Id = @streamId;
 
          IF @streamIdInternal IS NULL
             BEGIN
@@ -25,10 +25,10 @@ BEGIN TRANSACTION AppendStream;
        ELSE
            BEGIN
                  SELECT TOP(1)
-                         @latestStreamVersion = Events.StreamVersion
-                    FROM Events
-                   WHERE Events.StreamIDInternal = @streamIdInternal
-                ORDER BY Events.Ordinal DESC;
+                         @latestStreamVersion = dbo.Events.StreamVersion
+                    FROM dbo.Events
+                   WHERE dbo.Events.StreamIDInternal = @streamIdInternal
+                ORDER BY dbo.Events.Ordinal DESC;
 
             INSERT INTO dbo.Events (StreamIdInternal, StreamVersion, Id, Created, [Type], JsonData, JsonMetadata)
                  SELECT @streamIdInternal,

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/DeleteStreamAnyVersion.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/DeleteStreamAnyVersion.sql
@@ -2,14 +2,14 @@ SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 BEGIN TRANSACTION DeleteStream
         DECLARE @streamIdInternal AS INT
 
-         SELECT @streamIdInternal = Streams.IdInternal
-           FROM Streams
-          WHERE Streams.Id = @streamId;
+         SELECT @streamIdInternal = dbo.Streams.IdInternal
+           FROM dbo.Streams
+          WHERE dbo.Streams.Id = @streamId;
 
-    DELETE FROM Events
-          WHERE Events.StreamIdInternal = @streamIdInternal;
+    DELETE FROM dbo.Events
+          WHERE dbo.Events.StreamIdInternal = @streamIdInternal;
 
-         UPDATE Streams
+         UPDATE dbo.Streams
             SET IsDeleted = '1'
-          WHERE Streams.Id = @streamId;
+          WHERE dbo.Streams.Id = @streamId;
 COMMIT TRANSACTION DeleteStream

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/DeleteStreamExpectedVersion.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/DeleteStreamExpectedVersion.sql
@@ -3,7 +3,7 @@ BEGIN TRANSACTION DeleteStream
         DECLARE @streamIdInternal AS INT;
         DECLARE @latestStreamVersion  AS INT;
 
-         SELECT @streamIdInternal = Streams.IdInternal
+         SELECT @streamIdInternal = dbo.Streams.IdInternal
            FROM Streams
           WHERE Streams.Id = @streamId;
 
@@ -15,10 +15,10 @@ BEGIN TRANSACTION DeleteStream
           END
 
           SELECT TOP(1)
-                @latestStreamVersion = Events.StreamVersion
-           FROM Events
-          WHERE Events.StreamIDInternal = @streamIdInternal
-       ORDER BY Events.Ordinal DESC;
+                @latestStreamVersion = dbo.Events.StreamVersion
+           FROM dbo.Events
+          WHERE dbo.Events.StreamIDInternal = @streamIdInternal
+       ORDER BY dbo.Events.Ordinal DESC;
 
          IF @latestStreamVersion != @expectedStreamVersion
          BEGIN
@@ -27,11 +27,11 @@ BEGIN TRANSACTION DeleteStream
             RETURN;
          END
 
-         UPDATE Streams
+         UPDATE dbo.Streams
             SET IsDeleted = '1'
-          WHERE Streams.Id = @streamId ;
+          WHERE dbo.Streams.Id = @streamId ;
 
-         DELETE FROM Events
-          WHERE Events.StreamIdInternal = @streamIdInternal;
+         DELETE FROM dbo.Events
+          WHERE dbo.Events.StreamIdInternal = @streamIdInternal;
 
 COMMIT TRANSACTION DeleteStream

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/DeleteStreamExpectedVersion.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/DeleteStreamExpectedVersion.sql
@@ -4,8 +4,8 @@ BEGIN TRANSACTION DeleteStream
         DECLARE @latestStreamVersion  AS INT;
 
          SELECT @streamIdInternal = dbo.Streams.IdInternal
-           FROM Streams
-          WHERE Streams.Id = @streamId;
+           FROM dbo.Streams
+          WHERE dbo.Streams.Id = @streamId;
 
           IF @streamIdInternal IS NULL
           BEGIN

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadAllBackward.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadAllBackward.sql
@@ -1,15 +1,15 @@
 /* SQL Server 2008+ */
      SELECT TOP(@count)
-            Streams.IdOriginal As StreamId,
-            Events.StreamVersion,
-            Events.Ordinal,
-            Events.Id AS EventId,
-            Events.Created,
-            Events.Type,
-            Events.JsonData,
-            Events.JsonMetadata
-       FROM Events
- INNER JOIN Streams
-         ON Events.StreamIdInternal=Streams.IdInternal
-      WHERE Events.Ordinal <= @ordinal
-   ORDER BY Events.Ordinal DESC;
+            dbo.Streams.IdOriginal As StreamId,
+            dbo.Events.StreamVersion,
+            dbo.Events.Ordinal,
+            dbo.Events.Id AS EventId,
+            dbo.Events.Created,
+            dbo.Events.Type,
+            dbo.Events.JsonData,
+            dbo.Events.JsonMetadata
+       FROM dbo.Events
+ INNER JOIN dbo.Streams
+         ON dbo.Events.StreamIdInternal = dbo.Streams.IdInternal
+      WHERE dbo.Events.Ordinal <= @ordinal
+   ORDER BY dbo.Events.Ordinal DESC;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadAllForward.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadAllForward.sql
@@ -1,15 +1,15 @@
 /* SQL Server 2008+ */
      SELECT TOP(@count)
-            Streams.IdOriginal As StreamId,
-            Events.StreamVersion,
-            Events.Ordinal,
-            Events.Id AS EventId,
-            Events.Created,
-            Events.Type,
-            Events.JsonData,
-            Events.JsonMetadata
-       FROM Events
- INNER JOIN Streams
-         ON Events.StreamIdInternal = Streams.IdInternal
-      WHERE Events.Ordinal >= @ordinal
-   ORDER BY Events.Ordinal;
+            dbo.Streams.IdOriginal As StreamId,
+            dbo.Events.StreamVersion,
+            dbo.Events.Ordinal,
+            dbo.Events.Id AS EventId,
+            dbo.Events.Created,
+            dbo.Events.Type,
+            dbo.Events.JsonData,
+            dbo.Events.JsonMetadata
+       FROM dbo.Events
+ INNER JOIN dbo.Streams
+         ON dbo.Events.StreamIdInternal = dbo.Streams.IdInternal
+      WHERE dbo.Events.Ordinal >= @ordinal
+   ORDER BY dbo.Events.Ordinal;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadHeadCheckpoint.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadHeadCheckpoint.sql
@@ -1,3 +1,3 @@
 /* SQL Server 2008+ */
-     SELECT MAX(Events.Ordinal)
-       FROM Events
+     SELECT MAX(dbo.Events.Ordinal)
+       FROM dbo.Events

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamBackward.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamBackward.sql
@@ -3,29 +3,29 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @isDeleted AS BIT
 
-     SELECT @streamIdInternal = Streams.IdInternal,
-            @isDeleted = Streams.IsDeleted
-       FROM Streams
-      WHERE Streams.Id = @streamId
+     SELECT @streamIdInternal = dbo.Streams.IdInternal,
+            @isDeleted = dbo.Streams.IsDeleted
+       FROM dbo.Streams
+      WHERE dbo.Streams.Id = @streamId
 
      SELECT @isDeleted;
 
      SELECT TOP(@count)
-            Events.StreamVersion,
-            Events.Ordinal,
-            Events.Id AS EventId,
-            Events.Created,
-            Events.Type,
-            Events.JsonData,
-            Events.JsonMetadata
-       FROM Events
+            dbo.Events.StreamVersion,
+            dbo.Events.Ordinal,
+            dbo.Events.Id AS EventId,
+            dbo.Events.Created,
+            dbo.Events.Type,
+            dbo.Events.JsonData,
+            dbo.Events.JsonMetadata
+       FROM dbo.Events
  INNER JOIN Streams
-         ON Events.StreamIdInternal = Streams.IdInternal
-      WHERE Events.StreamIDInternal = @streamIDInternal AND Events.StreamVersion <= @StreamVersion
-   ORDER BY Events.Ordinal DESC
+         ON dbo.Events.StreamIdInternal = dbo.Streams.IdInternal
+      WHERE dbo.Events.StreamIDInternal = @streamIDInternal AND dbo.Events.StreamVersion <= @StreamVersion
+   ORDER BY dbo.Events.Ordinal DESC
 
      SELECT TOP(1)
-            Events.StreamVersion
-       FROM Events
-      WHERE Events.StreamIDInternal = @streamIDInternal
-   ORDER BY Events.Ordinal DESC;
+            dbo.Events.StreamVersion
+       FROM dbo.Events
+      WHERE dbo.Events.StreamIDInternal = @streamIDInternal
+   ORDER BY dbo.Events.Ordinal DESC;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamBackward.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamBackward.sql
@@ -19,7 +19,7 @@
             dbo.Events.JsonData,
             dbo.Events.JsonMetadata
        FROM dbo.Events
- INNER JOIN Streams
+ INNER JOIN dbo.Streams
          ON dbo.Events.StreamIdInternal = dbo.Streams.IdInternal
       WHERE dbo.Events.StreamIDInternal = @streamIDInternal AND dbo.Events.StreamVersion <= @StreamVersion
    ORDER BY dbo.Events.Ordinal DESC

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamForward.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamForward.sql
@@ -19,7 +19,7 @@
             dbo.Events.JsonData,
             dbo.Events.JsonMetadata
        FROM dbo.Events
-      INNER JOIN dbo.Streams
+ INNER JOIN dbo.Streams
          ON dbo.Events.StreamIdInternal = dbo.Streams.IdInternal
       WHERE dbo.Events.StreamIDInternal = @streamIDInternal AND dbo.Events.StreamVersion >= @StreamVersion
    ORDER BY dbo.Events.Ordinal;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamForward.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/ReadStreamForward.sql
@@ -3,29 +3,29 @@
     DECLARE @streamIdInternal AS INT
     DECLARE @isDeleted AS BIT
 
-     SELECT @streamIdInternal = Streams.IdInternal,
-            @isDeleted = Streams.IsDeleted
-       FROM Streams
-      WHERE Streams.Id = @streamId
+     SELECT @streamIdInternal = dbo.Streams.IdInternal,
+            @isDeleted = dbo.Streams.IsDeleted
+       FROM dbo.Streams
+      WHERE dbo.Streams.Id = @streamId
 
      SELECT @isDeleted;
 
      SELECT TOP(@count)
-            Events.StreamVersion,
-            Events.Ordinal,
-            Events.Id AS EventId,
-            Events.Created,
-            Events.Type,
-            Events.JsonData,
-            Events.JsonMetadata
-       FROM Events
-      INNER JOIN Streams
-         ON Events.StreamIdInternal = Streams.IdInternal
-      WHERE Events.StreamIDInternal = @streamIDInternal AND Events.StreamVersion >= @StreamVersion
-   ORDER BY Events.Ordinal;
+            dbo.Events.StreamVersion,
+            dbo.Events.Ordinal,
+            dbo.Events.Id AS EventId,
+            dbo.Events.Created,
+            dbo.Events.Type,
+            dbo.Events.JsonData,
+            dbo.Events.JsonMetadata
+       FROM dbo.Events
+      INNER JOIN dbo.Streams
+         ON dbo.Events.StreamIdInternal = dbo.Streams.IdInternal
+      WHERE dbo.Events.StreamIDInternal = @streamIDInternal AND dbo.Events.StreamVersion >= @StreamVersion
+   ORDER BY dbo.Events.Ordinal;
 
      SELECT TOP(1)
-            Events.StreamVersion
-       FROM Events
-      WHERE Events.StreamIDInternal = @streamIDInternal
-   ORDER BY Events.Ordinal DESC;
+            dbo.Events.StreamVersion
+       FROM dbo.Events
+      WHERE dbo.Events.StreamIDInternal = @streamIDInternal
+   ORDER BY dbo.Events.Ordinal DESC;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/Scripts.cs
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/Scripts.cs
@@ -6,13 +6,13 @@
 
     internal class Scripts
     {
-        private readonly string _schema;
+        internal readonly string Schema;
         private readonly ConcurrentDictionary<string, string> _scripts 
             = new ConcurrentDictionary<string, string>();
 
         internal Scripts(string schema)
         {
-            _schema = schema;
+            Schema = schema;
         }
 
         internal string AppendStreamExpectedVersionAny => GetScript(nameof(AppendStreamExpectedVersionAny));
@@ -54,7 +54,9 @@
                         }
                         using(StreamReader reader = new StreamReader(stream))
                         {
-                            return reader.ReadToEnd();
+                            return reader
+                                .ReadToEnd()
+                                .Replace("dbo.", Schema + ".");
                         }
                     }
                 });

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/Scripts.cs
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/Scripts.cs
@@ -4,38 +4,44 @@
     using System.Collections.Concurrent;
     using System.IO;
 
-    internal static class Scripts
+    internal class Scripts
     {
-        private static readonly ConcurrentDictionary<string, string> s_scripts 
+        private readonly string _schema;
+        private readonly ConcurrentDictionary<string, string> _scripts 
             = new ConcurrentDictionary<string, string>();
 
-        internal static string AppendStreamExpectedVersionAny => GetScript(nameof(AppendStreamExpectedVersionAny));
-
-        internal static string AppendStreamExpectedVersion => GetScript(nameof(AppendStreamExpectedVersion));
-
-        internal static string AppendStreamExpectedVersionNoStream => GetScript(nameof(AppendStreamExpectedVersionNoStream));
-
-        internal static string DeleteStreamAnyVersion => GetScript(nameof(DeleteStreamAnyVersion));
-
-        internal static string DeleteStreamExpectedVersion => GetScript(nameof(DeleteStreamExpectedVersion));
-
-        internal static string DropAll => GetScript(nameof(DropAll));
-
-        internal static string InitializeStore => GetScript(nameof(InitializeStore));
-
-        internal static string ReadAllForward => GetScript(nameof(ReadAllForward));
-
-        internal static string ReadHeadCheckpoint => GetScript(nameof(ReadHeadCheckpoint));
-
-        internal static string ReadAllBackward => GetScript(nameof(ReadAllBackward));
-
-        internal static string ReadStreamForward => GetScript(nameof(ReadStreamForward));
-
-        internal static string ReadStreamBackward => GetScript(nameof(ReadStreamBackward));
-
-        private static string GetScript(string name)
+        internal Scripts(string schema)
         {
-            return s_scripts.GetOrAdd(name,
+            _schema = schema;
+        }
+
+        internal string AppendStreamExpectedVersionAny => GetScript(nameof(AppendStreamExpectedVersionAny));
+
+        internal string AppendStreamExpectedVersion => GetScript(nameof(AppendStreamExpectedVersion));
+
+        internal string AppendStreamExpectedVersionNoStream => GetScript(nameof(AppendStreamExpectedVersionNoStream));
+
+        internal string DeleteStreamAnyVersion => GetScript(nameof(DeleteStreamAnyVersion));
+
+        internal string DeleteStreamExpectedVersion => GetScript(nameof(DeleteStreamExpectedVersion));
+
+        internal string DropAll => GetScript(nameof(DropAll));
+
+        internal string InitializeStore => GetScript(nameof(InitializeStore));
+
+        internal string ReadAllForward => GetScript(nameof(ReadAllForward));
+
+        internal string ReadHeadCheckpoint => GetScript(nameof(ReadHeadCheckpoint));
+
+        internal string ReadAllBackward => GetScript(nameof(ReadAllBackward));
+
+        internal string ReadStreamForward => GetScript(nameof(ReadStreamForward));
+
+        internal string ReadStreamBackward => GetScript(nameof(ReadStreamBackward));
+
+        private string GetScript(string name)
+        {
+            return _scripts.GetOrAdd(name,
                 key =>
                 {
                     using(Stream stream = typeof(Scripts)


### PR DESCRIPTION
`MsSqlEventStore` ctor allows supplying of an optional schema name. If none supplied, it defaults to `dbo`. Fixes #5 