### PR TITLE
Correcting AssemblyName so MsSql tests are run

### DIFF
--- a/src/Cedar.EventStore.MsSql2008.Tests/Cedar.EventStore.MsSql2008.Tests.csproj
+++ b/src/Cedar.EventStore.MsSql2008.Tests/Cedar.EventStore.MsSql2008.Tests.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cedar.EventStore</RootNamespace>
-    <AssemblyName>Cedar.EventStore.MsSql.Tests</AssemblyName>
+    <AssemblyName>Cedar.EventStore.MsSql2008.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
Running `.\build.ps1` fails to find the `Cedar.EventStore.MsSql.Tests.dll` as it is not named as per the convention where the projectname is the folder and dll name.

This PR changes the AssemblyName of the MsSql test so that is matches the folder ad project name. This allows the `.\Build.ps1` to find the tests.