### PR TITLE
Build script fail on Xunit test failures

### DIFF
--- a/src/Cedar.EventStore.MsSql2008.Tests/Cedar.EventStore.MsSql2008.Tests.csproj
+++ b/src/Cedar.EventStore.MsSql2008.Tests/Cedar.EventStore.MsSql2008.Tests.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cedar.EventStore</RootNamespace>
-    <AssemblyName>Cedar.EventStore.MsSql.Tests</AssemblyName>
+    <AssemblyName>Cedar.EventStore.MsSql2008.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
This PR is based off the PR #16 

* Wrap the call to xunit in an `exec` statement to throw when xunit exists with non-zero exit code
* Consistent formatting of  curlies and params 
* Commented out the un-built tests (`GetEventStore`, `Postgres` & `SqlLite`)
* Hide the dump of the `System.Xml.Linq` type information by capturing it as a variable.