### PR TITLE
Insert events into MSSQL in deterministic order

### DIFF
--- a/src/Cedar.EventStore.MsSql2008.Tests/Cedar.EventStore.MsSql2008.Tests.csproj
+++ b/src/Cedar.EventStore.MsSql2008.Tests/Cedar.EventStore.MsSql2008.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="EventStoreAcceptanceTests.ReadLongStreamInPages.cs" />
     <Compile Include="ExploratoryTests.cs" />
     <Compile Include="MsSqlEventStoreFixture.cs" />
     <Compile Include="MsSqlEventStoreTests.cs" />

--- a/src/Cedar.EventStore.MsSql2008.Tests/EventStoreAcceptanceTests.ReadLongStreamInPages.cs
+++ b/src/Cedar.EventStore.MsSql2008.Tests/EventStoreAcceptanceTests.ReadLongStreamInPages.cs
@@ -1,0 +1,88 @@
+﻿namespace Cedar.EventStore
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using Cedar.EventStore.Streams;
+    using Shouldly;
+    using Xunit;
+
+    public partial class EventStoreAcceptanceTests
+    {
+        [Fact]
+        public async Task Given_large_event_stream_can_be_read_back_in_pages()
+        {
+            using (var fixture = GetFixture())
+            {
+                using (var eventStore = await fixture.GetEventStore())
+                {
+                    var eventsToWrite = CreateNewStreamEvents();
+
+                    await eventStore.AppendToStream("stream-1", ExpectedVersion.NoStream, eventsToWrite);
+
+
+                    var readEvents = await new PagedEventStore(eventStore).GetAsync("stream-1");
+
+                    readEvents.Count().ShouldBe(eventsToWrite.Length);
+                }
+            }
+        }
+
+        private static NewStreamEvent[] CreateNewStreamEvents()
+        {
+            var eventsToWrite = new List<NewStreamEvent>();
+            var largeStreamCount = 7500;
+            for (int i = 0; i < largeStreamCount; i++)
+            {
+                var envelope = new NewStreamEvent(Guid.NewGuid(), $"event{i}", "{}", $"{i}");
+
+                eventsToWrite.Add(envelope);
+            }
+
+            return eventsToWrite.ToArray();
+        }
+    }
+
+    public class PagedEventStore
+    {
+        private readonly IEventStore _eventStore;
+
+        public PagedEventStore(IEventStore eventStore)
+        {
+            _eventStore = eventStore;
+        }
+
+        public async Task<IEnumerable<StreamEvent>> GetAsync(string streamName)
+        {
+            var start = 0;
+            const int BatchSize = 500;
+
+            StreamEventsPage eventsPage;
+            var events = new List<StreamEvent>();
+
+            do
+            {
+                eventsPage = await _eventStore.ReadStreamForwards(streamName, start, BatchSize);
+
+                if (eventsPage.Status == PageReadStatus.StreamDeleted)
+                {
+                    throw new Exception("Stream deleted");
+                }
+
+                if (eventsPage.Status == PageReadStatus.StreamNotFound)
+                {
+                    throw new Exception("Stream not found");
+                }
+
+                events.AddRange(
+                    eventsPage.Events);
+
+                start = eventsPage.NextStreamVersion;
+            }
+            while (!eventsPage.IsEndOfStream);
+
+            return events;
+        }
+    }
+}

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersion.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersion.sql
@@ -35,6 +35,7 @@ INSERT INTO dbo.Events (StreamIdInternal, StreamVersion, Id, Created, [Type], Js
             [Type],
             JsonData,
             JsonMetadata
-       FROM @newEvents;
+       FROM @newEvents
+   ORDER BY StreamVersion;
  
 COMMIT TRANSACTION AppendStream;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersionAny.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersionAny.sql
@@ -20,7 +20,8 @@ BEGIN TRANSACTION AppendStream;
                         [Type],
                         JsonData,
                         JsonMetadata
-                   FROM @newEvents;
+                   FROM @newEvents
+               ORDER BY StreamVersion;
             END
        ELSE
            BEGIN
@@ -38,6 +39,7 @@ BEGIN TRANSACTION AppendStream;
                         [Type],
                         JsonData,
                         JsonMetadata
-                   FROM @newEvents;
+                   FROM @newEvents
+               ORDER BY StreamVersion;
            END
 COMMIT TRANSACTION AppendStream;

--- a/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersionNoStream.sql
+++ b/src/Cedar.EventStore.MsSql2008/SqlScripts/AppendStreamExpectedVersionNoStream.sql
@@ -13,7 +13,8 @@ BEGIN TRANSACTION CreateStream;
                     [Type],
                     JsonData,
                     JsonMetadata
-               FROM @newEvents;
+               FROM @newEvents
+           ORDER BY StreamVersion;
  
     END;
     SELECT @streamIdInternal;


### PR DESCRIPTION
I believe this closes #19 

The change is based on a simple idea: `SELECT` queries do not have any guarantees of ordering unless you specify an `ORDER BY`. When any insert is being made, it is being done from a `dbo.NewStreamEvents` Table Value type parameter. This data is in an order, but that doesn't mean that it will be read in that order, which means it will not be inserted in that order. By simply specifying the `ORDER BY StreamVersion;` we can ensure that inserts will be in the order we expected.

I have added the test provided in #19, and was able to have it fail fairly consistently without the `ORDER BY` clauses. I have run the tests a dozen times since adding the `ORDER BY` clause and have not seen a failure.

Note this did _NOT_ fix the other two failing tests.